### PR TITLE
Update build-lib.yml: rename artifact from "forms-aar" to "viewmodelfactory-aar"

### DIFF
--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -98,7 +98,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - uses: actions/download-artifact@master
         with:
-          name: forms-aar
+          name: viewmodelfactory-aar
           path: ./
       - name: release
         uses: actions/create-release@v1


### PR DESCRIPTION
This commit updates the build-lib.yml file by changing the name of the artifact from "forms-aar" to "viewmodelfactory-aar". This change ensures that the correct artifact is downloaded during the workflow.